### PR TITLE
Input encoding for kakasi library call set to "euc"

### DIFF
--- a/kanjitranscript/kanjitranscript.c
+++ b/kanjitranscript/kanjitranscript.c
@@ -42,7 +42,7 @@ Datum osml10n_kanji_transcript(PG_FUNCTION_ARGS) {
   size_t numchars;
   unsigned i;
   char *kakasi_out;
-  char *kakasi_argv[6]={"kakasi","-Ja","-Ha","-Ka","-Ea","-s"};
+  char *kakasi_argv[6]={"kakasi","-i","euc","-Ja","-Ha","-Ka","-Ea","-s"};
   
   if (GetDatabaseEncoding() != PG_UTF8) {
     ereport(ERROR,(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
@@ -132,7 +132,7 @@ Datum osml10n_kanji_transcript(PG_FUNCTION_ARGS) {
   // 4. run kakasi transliteration
   
   // run kakasi on eucjp string
-  kakasi_getopt_argv(6,kakasi_argv);
+  kakasi_getopt_argv(8,kakasi_argv);
   kakasi_out=kakasi_do(converted_start);
   free(converted_start);
   if (kakasi_out==NULL) {


### PR DESCRIPTION
I had a problem restoring a dumped openmaptiles database with pg_restore.
It turned out that there were invalid UTF-8 characters in some tag values in several tables of the original database. I tracked a specific case down to the kakasi call in osml10n_kanji_transcript(...), where the input encoding for the call to kakasi_getopt_argv(...) is not set.
The problematic character sequence is:

莪原町

It is the name of the OSM-Node 2155546745 https://www.openstreetmap.org/node/2155546745

What's basically done in osml10n_kanji_transcript(...) is comparable to this

```
echo "莪原町" | iconv -f utf8 -t eucjp | kakasi -Ja -Ha -Ka -Ea -s

sui ▒▒Į
```
The result is exactly what I found in the database dump, containing the invalid UTF-8 characters.

If the input encoding for the call to kakasi is set to 'euc' (this is the encoding the UTF-8 string fed to osml10n_kanji_transcript is converted to), the output looks pretty ok and reasonable and does not contain invalid character sequences

```
echo "莪原町" | iconv -f utf8 -t eucjp | kakasi -i euc -Ja -Ha -Ka -Ea -s

waibara machi
```

This fix adds the missing input encoding argument to the kakasi library call.